### PR TITLE
Polish comment thread UI and rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discussing",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "React components for fetching and displaying comments from external discussion platforms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Discussion.tsx
+++ b/src/components/Discussion.tsx
@@ -1,7 +1,11 @@
 'use client'
 
 import React, { useState, useCallback, useEffect } from 'react'
+import { formatRelativeTime, renderCommentContent } from '../utils/comment-format'
 import type { ExternalDiscussion, Comment, FetchOptions } from '../types'
+
+/** Top-level comments shown before the rest collapse behind a "show more" disclosure. */
+const VISIBLE_COMMENTS = 8
 
 interface DiscussionProps {
   discussions?: ExternalDiscussion[]
@@ -139,57 +143,59 @@ export default function Discussion({
 
   return (
     <div className={`mt-16 ${className}`}>
-      <div className="space-y-12">
+      <div className="space-y-14">
         {discussions.map((discussion) => {
           const platformComments = commentsByPlatform[discussion.platform] || []
           const isLoading = loading[discussion.platform]
           const hasError = error[discussion.platform]
-          
+
           return (
-            <div key={`${discussion.platform}-${discussion.url}`}>
+            <section key={`${discussion.platform}-${discussion.url}`}>
               {/* Section divider with platform name */}
-              <div className="flex items-center mb-8">
-                <div className="flex-1 border-t border-gray-200"></div>
-                <div className="px-4 text-sm text-gray-600">
-                    <span>Discussing on </span>
-                    <a
-                      href={discussion.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-gray-900 font-medium hover:text-gray-700"
-                      style={{ textDecoration: 'none' }}
-                    >
+              <div className="flex items-center gap-4 mb-10">
+                <div className="flex-1 border-t border-gray-200 dark:border-gray-700/70"></div>
+                <div className="inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">
+                  <a
+                    href={discussion.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group inline-flex items-center gap-1.5 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <span>Discussing on</span>
+                    <span className="font-semibold text-gray-600 dark:text-gray-300 group-hover:text-gray-900 dark:group-hover:text-gray-100">
                       {getPlatformName(discussion.platform)}
-                    </a>
-                    {isLoading && (
-                      <>
-                        <span className="mx-2">·</span>
-                        <span className="text-gray-500">Loading comments...</span>
-                      </>
-                    )}
-                    {enableRefresh && !isLoading && (
-                      <>
-                        <span className="mx-2">·</span>
-                        <button
-                          onClick={refreshComments}
-                          className="text-gray-500 hover:text-gray-700 text-xs underline"
-                        >
-                          Refresh
-                        </button>
-                      </>
-                    )}
+                    </span>
+                  </a>
+                  {isLoading && (
+                    <>
+                      <span className="text-gray-300 dark:text-gray-600">·</span>
+                      <span className="normal-case tracking-normal">Loading…</span>
+                    </>
+                  )}
+                  {enableRefresh && !isLoading && (
+                    <>
+                      <span className="text-gray-300 dark:text-gray-600">·</span>
+                      <button
+                        onClick={refreshComments}
+                        className="normal-case tracking-normal hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                      >
+                        Refresh
+                      </button>
+                    </>
+                  )}
                 </div>
-                <div className="flex-1 border-t border-gray-200"></div>
+                <div className="flex-1 border-t border-gray-200 dark:border-gray-700/70"></div>
               </div>
 
               {hasError && (
                 <div className="text-center py-4">
-                  <div className="text-sm text-red-600 mb-2">
+                  <div className="text-sm text-red-600 dark:text-red-400 mb-2">
                     Failed to load comments: {hasError}
                   </div>
                   <button
                     onClick={refreshComments}
-                    className="text-sm text-gray-600 hover:text-gray-800 underline"
+                    className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 underline"
                   >
                     Retry
                   </button>
@@ -197,23 +203,45 @@ export default function Discussion({
               )}
 
               {!hasError && platformComments.length > 0 && (
-                <div className="mt-6">
-                  {platformComments.map((comment) => (
-                    <CommentItem 
-                      key={comment.id} 
-                      comment={comment} 
-                      ImageComponent={ImageComponent}
-                    />
-                  ))}
-                </div>
+                <>
+                  <div className="space-y-7">
+                    {platformComments.slice(0, VISIBLE_COMMENTS).map((comment) => (
+                      <CommentItem
+                        key={comment.id}
+                        comment={comment}
+                        ImageComponent={ImageComponent}
+                      />
+                    ))}
+                  </div>
+
+                  {platformComments.length > VISIBLE_COMMENTS && (
+                    <details className="group mt-7">
+                      <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                        <span className="group-open:hidden">
+                          Show {platformComments.length - VISIBLE_COMMENTS} more comments
+                        </span>
+                        <span className="hidden group-open:inline">Show fewer comments</span>
+                      </summary>
+                      <div className="space-y-7 mt-7">
+                        {platformComments.slice(VISIBLE_COMMENTS).map((comment) => (
+                          <CommentItem
+                            key={comment.id}
+                            comment={comment}
+                            ImageComponent={ImageComponent}
+                          />
+                        ))}
+                      </div>
+                    </details>
+                  )}
+                </>
               )}
 
               {!isLoading && !hasError && platformComments.length === 0 && (
-                <div className="text-xs text-gray-500 mt-2 text-center">
-                  No comments found.
-                </div>
+                <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-2">
+                  No comments yet.
+                </p>
               )}
-            </div>
+            </section>
           )
         })}
       </div>
@@ -230,13 +258,7 @@ function CommentItem({
   depth?: number;
   ImageComponent?: DiscussionProps['ImageComponent']
 }) {
-  const formatDate = (timestamp: string) => {
-    const date = new Date(timestamp)
-    return date.toLocaleDateString(undefined, { 
-      month: 'short', 
-      day: 'numeric'
-    })
-  }
+  const { label: timeLabel, title: timeTitle } = formatRelativeTime(comment.timestamp)
 
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement>) => {
     const target = e.target as HTMLImageElement;
@@ -247,64 +269,89 @@ function CommentItem({
     }
   }
 
+  const size = depth > 0 ? 28 : 36
+
   return (
-    <div className={`mb-4 ${depth > 0 ? 'ml-6' : ''}`}>
-      <blockquote className="border-l-2 border-gray-300 pl-5 py-2 relative">
-        <div className="text-sm text-gray-500 flex items-center justify-between pl-3 mb-3">
-          <div className="flex items-center gap-3">
-            <div className="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium text-gray-600 flex-shrink-0 overflow-hidden">
-              {comment.avatar && ImageComponent ? (
-                <ImageComponent 
-                  src={comment.avatar} 
-                  alt={comment.author}
-                  width={24}
-                  height={24}
-                  className="w-full h-full object-cover rounded-full"
-                  onError={handleImageError}
-                />
-              ) : comment.avatar ? (
-                <img 
-                  src={comment.avatar} 
-                  alt={comment.author}
-                  className="w-full h-full object-cover rounded-full"
-                  onError={handleImageError}
-                />
-              ) : (
-                comment.author.charAt(0).toUpperCase()
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-gray-600">{comment.author}</span>
-              <span className="text-gray-400">·</span>
-              <span className="text-gray-500">{formatDate(comment.timestamp)}</span>
-            </div>
-          </div>
+    <div className="flex gap-3">
+      {/* Avatar */}
+      <div
+        className="flex-shrink-0 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-black/[0.06] dark:ring-white/10 flex items-center justify-center text-xs font-semibold text-gray-500 dark:text-gray-400 select-none"
+        style={{ width: size, height: size }}
+      >
+        {comment.avatar && ImageComponent ? (
+          <ImageComponent
+            src={comment.avatar}
+            alt={comment.author}
+            width={size}
+            height={size}
+            className="w-full h-full object-cover"
+            onError={handleImageError}
+          />
+        ) : comment.avatar ? (
+          <img
+            src={comment.avatar}
+            alt={comment.author}
+            className="w-full h-full object-cover"
+            onError={handleImageError}
+          />
+        ) : (
+          comment.author.charAt(0).toUpperCase()
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 mb-1">
+          <span className="font-medium text-[0.9375rem] text-gray-900 dark:text-gray-100 truncate">
+            {comment.author}
+          </span>
+          <span className="text-gray-300 dark:text-gray-600">·</span>
+          <time title={timeTitle} className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+            {timeLabel}
+          </time>
           {comment.votes !== undefined && (
-            <span className="text-gray-400 text-xs">{comment.votes} points</span>
+            <span className="ml-auto text-xs text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
+              {comment.votes} points
+            </span>
           )}
         </div>
-        <div className="text-gray-600 leading-relaxed whitespace-pre-wrap text-base">
-          {comment.content}
+        <div className="text-[0.9375rem] leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+          {renderCommentContent(comment.content)}
         </div>
-      </blockquote>
-      
-      {comment.replies && comment.replies.length > 0 && (
-        <div className="mt-2">
-          {comment.replies.slice(0, 2).map((reply: Comment) => (
-            <CommentItem 
-              key={reply.id} 
-              comment={reply} 
-              depth={depth + 1} 
-              ImageComponent={ImageComponent}
-            />
-          ))}
-          {comment.replies.length > 2 && (
-            <div className="text-sm text-gray-500 ml-6 mb-4">
-              {comment.replies.length - 2} more replies...
-            </div>
-          )}
-        </div>
-      )}
+
+        {comment.replies && comment.replies.length > 0 && (
+          <div className="mt-5 space-y-5 border-l border-gray-100 dark:border-gray-800 pl-4">
+            {comment.replies.slice(0, 2).map((reply: Comment) => (
+              <CommentItem
+                key={reply.id}
+                comment={reply}
+                depth={depth + 1}
+                ImageComponent={ImageComponent}
+              />
+            ))}
+            {comment.replies.length > 2 && (
+              <details className="group/replies">
+                <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                  <span className="group-open/replies:hidden">
+                    Show {comment.replies.length - 2} more {comment.replies.length - 2 === 1 ? 'reply' : 'replies'}
+                  </span>
+                  <span className="hidden group-open/replies:inline">Show fewer replies</span>
+                </summary>
+                <div className="mt-5 space-y-5">
+                  {comment.replies.slice(2).map((reply: Comment) => (
+                    <CommentItem
+                      key={reply.id}
+                      comment={reply}
+                      depth={depth + 1}
+                      ImageComponent={ImageComponent}
+                    />
+                  ))}
+                </div>
+              </details>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/DiscussionServer.tsx
+++ b/src/components/DiscussionServer.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { fetchAllExternalComments } from '../utils/fetch-comments'
+import { formatRelativeTime, renderCommentContent } from '../utils/comment-format'
 import type { ExternalDiscussion, Comment, FetchOptions } from '../types'
+
+/** Top-level comments shown before the rest collapse behind a "show more" disclosure. */
+const VISIBLE_COMMENTS = 8
 
 interface DiscussionServerProps {
   discussions?: ExternalDiscussion[]
@@ -52,48 +56,68 @@ export default async function DiscussionServer({
 
   return (
     <div className={`mt-16 ${className}`}>
-      <div className="space-y-12">
+      <div className="space-y-14">
         {discussions.map((discussion) => {
           const platformComments = commentsByPlatform[discussion.platform] || []
-          
+
           return (
-            <div key={`${discussion.platform}-${discussion.url}`}>
+            <section key={`${discussion.platform}-${discussion.url}`}>
               {/* Section divider with platform name */}
-              <div className="flex items-center mb-8">
-                <div className="flex-1 border-t border-gray-200"></div>
-                <div className="px-4 text-sm text-gray-600">
-                  <span>Discussing on </span>
-                  <a
-                    href={discussion.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-gray-900 font-medium hover:text-gray-700"
-                    style={{ textDecoration: 'none' }}
-                  >
+              <div className="flex items-center gap-4 mb-10">
+                <div className="flex-1 border-t border-gray-200 dark:border-gray-700/70"></div>
+                <a
+                  href={discussion.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                  style={{ textDecoration: 'none' }}
+                >
+                  <span>Discussing on</span>
+                  <span className="font-semibold text-gray-600 dark:text-gray-300 group-hover:text-gray-900 dark:group-hover:text-gray-100">
                     {getPlatformName(discussion.platform)}
-                  </a>
-                </div>
-                <div className="flex-1 border-t border-gray-200"></div>
+                  </span>
+                </a>
+                <div className="flex-1 border-t border-gray-200 dark:border-gray-700/70"></div>
               </div>
 
-              {platformComments.length > 0 && (
-                <div className="mt-6">
-                  {platformComments.map((comment) => (
-                    <CommentItem 
-                      key={comment.id} 
-                      comment={comment} 
-                      ImageComponent={ImageComponent}
-                    />
-                  ))}
-                </div>
-              )}
+              {platformComments.length > 0 ? (
+                <>
+                  <div className="space-y-7">
+                    {platformComments.slice(0, VISIBLE_COMMENTS).map((comment) => (
+                      <CommentItem
+                        key={comment.id}
+                        comment={comment}
+                        ImageComponent={ImageComponent}
+                      />
+                    ))}
+                  </div>
 
-              {platformComments.length === 0 && (
-                <div className="text-xs text-gray-500 mt-2 text-center">
-                  No comments found.
-                </div>
+                  {platformComments.length > VISIBLE_COMMENTS && (
+                    <details className="group mt-7">
+                      <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                        <span className="group-open:hidden">
+                          Show {platformComments.length - VISIBLE_COMMENTS} more comments
+                        </span>
+                        <span className="hidden group-open:inline">Show fewer comments</span>
+                      </summary>
+                      <div className="space-y-7 mt-7">
+                        {platformComments.slice(VISIBLE_COMMENTS).map((comment) => (
+                          <CommentItem
+                            key={comment.id}
+                            comment={comment}
+                            ImageComponent={ImageComponent}
+                          />
+                        ))}
+                      </div>
+                    </details>
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-2">
+                  No comments yet.
+                </p>
               )}
-            </div>
+            </section>
           )
         })}
       </div>
@@ -110,70 +134,88 @@ function CommentItem({
   depth?: number;
   ImageComponent?: DiscussionServerProps['ImageComponent']
 }) {
-  const formatDate = (timestamp: string) => {
-    const date = new Date(timestamp)
-    return date.toLocaleDateString(undefined, { 
-      month: 'short', 
-      day: 'numeric'
-    })
-  }
+  const { label: timeLabel, title: timeTitle } = formatRelativeTime(comment.timestamp)
+  const size = depth > 0 ? 28 : 36
 
   return (
-    <div className={`mb-4 ${depth > 0 ? 'ml-6' : ''}`}>
-      <blockquote className="border-l-2 border-gray-300 pl-5 py-2 relative">
-        <div className="text-sm text-gray-500 flex items-center justify-between pl-3 mb-3">
-          <div className="flex items-center gap-3">
-            <div className="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium text-gray-600 flex-shrink-0 overflow-hidden">
-              {comment.avatar && ImageComponent ? (
-                <ImageComponent 
-                  src={comment.avatar} 
-                  alt={comment.author}
-                  width={24}
-                  height={24}
-                  className="w-full h-full object-cover rounded-full"
-                />
-              ) : comment.avatar ? (
-                <img 
-                  src={comment.avatar} 
-                  alt={comment.author}
-                  className="w-full h-full object-cover rounded-full"
-                />
-              ) : (
-                comment.author.charAt(0).toUpperCase()
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-gray-600">{comment.author}</span>
-              <span className="text-gray-400">·</span>
-              <span className="text-gray-500">{formatDate(comment.timestamp)}</span>
-            </div>
-          </div>
+    <div className="flex gap-3">
+      {/* Avatar */}
+      <div
+        className="flex-shrink-0 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-black/[0.06] dark:ring-white/10 flex items-center justify-center text-xs font-semibold text-gray-500 dark:text-gray-400 select-none"
+        style={{ width: size, height: size }}
+      >
+        {comment.avatar && ImageComponent ? (
+          <ImageComponent
+            src={comment.avatar}
+            alt={comment.author}
+            width={size}
+            height={size}
+            className="w-full h-full object-cover"
+          />
+        ) : comment.avatar ? (
+          <img
+            src={comment.avatar}
+            alt={comment.author}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          comment.author.charAt(0).toUpperCase()
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 mb-1">
+          <span className="font-medium text-[0.9375rem] text-gray-900 dark:text-gray-100 truncate">
+            {comment.author}
+          </span>
+          <span className="text-gray-300 dark:text-gray-600">·</span>
+          <time title={timeTitle} className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+            {timeLabel}
+          </time>
           {comment.votes !== undefined && (
-            <span className="text-gray-400 text-xs">{comment.votes} points</span>
+            <span className="ml-auto text-xs text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
+              {comment.votes} points
+            </span>
           )}
         </div>
-        <div className="text-gray-600 leading-relaxed whitespace-pre-wrap text-base">
-          {comment.content}
+        <div className="text-[0.9375rem] leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+          {renderCommentContent(comment.content)}
         </div>
-      </blockquote>
-      
-      {comment.replies && comment.replies.length > 0 && (
-        <div className="mt-2">
-          {comment.replies.slice(0, 2).map((reply: Comment) => (
-            <CommentItem 
-              key={reply.id} 
-              comment={reply} 
-              depth={depth + 1} 
-              ImageComponent={ImageComponent}
-            />
-          ))}
-          {comment.replies.length > 2 && (
-            <div className="text-sm text-gray-500 ml-6 mb-4">
-              {comment.replies.length - 2} more replies...
-            </div>
-          )}
-        </div>
-      )}
+
+        {comment.replies && comment.replies.length > 0 && (
+          <div className="mt-5 space-y-5 border-l border-gray-100 dark:border-gray-800 pl-4">
+            {comment.replies.slice(0, 2).map((reply: Comment) => (
+              <CommentItem
+                key={reply.id}
+                comment={reply}
+                depth={depth + 1}
+                ImageComponent={ImageComponent}
+              />
+            ))}
+            {comment.replies.length > 2 && (
+              <details className="group/replies">
+                <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                  <span className="group-open/replies:hidden">
+                    Show {comment.replies.length - 2} more {comment.replies.length - 2 === 1 ? 'reply' : 'replies'}
+                  </span>
+                  <span className="hidden group-open/replies:inline">Show fewer replies</span>
+                </summary>
+                <div className="mt-5 space-y-5">
+                  {comment.replies.slice(2).map((reply: Comment) => (
+                    <CommentItem
+                      key={reply.id}
+                      comment={reply}
+                      depth={depth + 1}
+                      ImageComponent={ImageComponent}
+                    />
+                  ))}
+                </div>
+              </details>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/utils/comment-format.tsx
+++ b/src/utils/comment-format.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+
+/**
+ * Format a timestamp as a compact relative label (e.g. "3 days ago"),
+ * along with a full absolute string suitable for a `title` tooltip.
+ */
+export function formatRelativeTime(timestamp: string): { label: string; title: string } {
+  const date = new Date(timestamp)
+
+  if (isNaN(date.getTime())) {
+    return { label: timestamp, title: timestamp }
+  }
+
+  const title = date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+
+  const seconds = Math.round((Date.now() - date.getTime()) / 1000)
+  const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? '' : 's'} ago`
+
+  if (seconds < 45) return { label: 'just now', title }
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return { label: plural(minutes, 'min'), title }
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return { label: plural(hours, 'hour'), title }
+  const days = Math.round(hours / 24)
+  if (days < 7) return { label: plural(days, 'day'), title }
+  const weeks = Math.round(days / 7)
+  if (days < 30) return { label: plural(weeks, 'week'), title }
+  const months = Math.round(days / 30)
+  if (days < 365) return { label: plural(months, 'month'), title }
+  const years = Math.round(days / 365)
+  return { label: plural(years, 'year'), title }
+}
+
+/**
+ * Normalize comment whitespace, then render it as React nodes with
+ * `@mentions` styled as subtle reply tokens and bare URLs turned into links.
+ *
+ * The returned text segments preserve newlines, so the host element should
+ * still use `whitespace-pre-wrap`.
+ */
+export function renderCommentContent(raw: string): React.ReactNode[] {
+  // Normalize whitespace.
+  let text = raw.replace(/\r\n/g, '\n').trim()
+  // Collapse 3+ blank lines down to a single blank line.
+  text = text.replace(/\n{3,}/g, '\n\n')
+  // Drop the dead gap between leading @mentions and the reply body.
+  text = text.replace(/^((?:@[A-Za-z0-9_-]+[ \t]*)+)\n\s*\n/, '$1\n')
+
+  const nodes: React.ReactNode[] = []
+  const pattern = /(https?:\/\/[^\s]+)|(@[A-Za-z0-9_-]+)/g
+  let lastIndex = 0
+  let key = 0
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index))
+    }
+
+    if (match[1]) {
+      // URL — strip trailing sentence punctuation so it isn't swallowed by the link.
+      let url = match[1]
+      let trailing = ''
+      const punct = url.match(/[.,;:!?)\]}'"]+$/)
+      if (punct) {
+        trailing = punct[0]
+        url = url.slice(0, -trailing.length)
+      }
+      nodes.push(
+        <a
+          key={`link-${key++}`}
+          href={url}
+          target="_blank"
+          rel="nofollow noopener noreferrer"
+          className="text-blue-600 dark:text-blue-400 hover:underline break-all"
+        >
+          {url}
+        </a>
+      )
+      if (trailing) nodes.push(trailing)
+    } else if (match[2]) {
+      nodes.push(
+        <span key={`mention-${key++}`} className="font-medium text-gray-500 dark:text-gray-400">
+          {match[2]}
+        </span>
+      )
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex))
+  }
+
+  return nodes
+}


### PR DESCRIPTION
## Summary

Improves the visual quality and readability of rendered discussions in both `DiscussionServer` (zero-JS RSC) and `Discussion` (client) components.

### Layout redesign
- Replaces the old `blockquote` / left quote-bar layout — whose bar collided with comment avatars — with a clean **avatar-gutter thread row**.
- Clearer author / timestamp / content hierarchy; subtle threaded reply indent with a light rule.
- Full `dark:` variants throughout so the library is portable.

### Content rendering (new shared `comment-format` util)
- **Whitespace normalization** — trims, collapses 3+ blank lines, and removes the dead gap left after a leading `@mention` (the common V2EX/Reddit reply shape `@user\n\nbody`).
- **@mentions** rendered as subtle inline tokens instead of bare text.
- **Bare URLs auto-linked** with `rel="nofollow noopener noreferrer"`; trailing sentence punctuation is excluded from the link.

### Other
- **Relative timestamps** ("3 days ago") with the absolute date as a `title` tooltip.
- **Long threads collapse** behind JS-free `<details>` disclosures ("Show N more comments" / "Show N more replies"), so the server component stays zero-JS.

Bumped to **1.8.0**.

## Testing
- `npm run build` ✓
- `npm test` — 43/43 ✓
- Content rendering + relative-time logic unit-checked (links, inline/leading mentions, blank-line collapse, punctuation handling).
- Verified live in blog.minghe.me against a real V2EX thread.