### PR TITLE
fix(ci): make auto-version skip check robust to multi-line commits

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -21,8 +21,13 @@ jobs:
         
     - name: Check if should skip
       id: should_skip
+      env:
+        # Pass the commit message via the environment instead of inlining it
+        # into the script. Inlining breaks the `[[ ]]` test for multi-line
+        # messages or ones containing backticks/quotes (shell injection).
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
-        if [[ "${{ github.event.head_commit.message }}" == *"chore: release v"* ]]; then
+        if [[ "$COMMIT_MESSAGE" == *"chore: release v"* ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT
           echo "Skipping - this is already a release commit"
         else


### PR DESCRIPTION
## Problem

The **Auto Version Bump** workflow fails on push to `main` ([example run](https://github.com/metrue/discussing/actions/runs/27915943144/job/82601176336)):

```
/home/runner/work/_temp/....sh: line 13: conditional binary operator expected
##[error]Process completed with exit code 2.
```

The "Check if should skip" step inlines the commit message straight into a bash test:

```bash
if [[ "${{ github.event.head_commit.message }}" == *"chore: release v"* ]]; then
```

GitHub substitutes the **raw** message into the script *before* the shell runs. Any multi-line message — or one containing backticks/quotes — breaks the `[[ ]]` conditional (and is a shell-injection vector). This is why the job has **never succeeded**, including on the very first commit back in Oct 2025.

## Fix

Pass the message through an `env:` variable so the shell receives it as data, not interpolated script text:

```yaml
env:
  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
run: |
  if [[ "$COMMIT_MESSAGE" == *"chore: release v"* ]]; then
```

This is GitHub's recommended pattern for using event data in scripts.

## Verification

Reproduced locally with the exact failing commit message:
- **Before** (inline): `conditional binary operator expected` ❌
- **After** (env var): exits 0, prints `skip=false` ✅

## Note

This is the first time the job will actually run to completion. On merge it will `npm version minor` (1.8.0 → **1.9.0**), create a GitHub release, and publish to npm. `blog.minghe.me` depends on `^1.8.0`, which accepts 1.9.0 — so the pending blog PR (Cofe#88) is unblocked once this publishes.